### PR TITLE
Fix spans bug when scatter or client_desires_new_key creates a task

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -99,7 +99,7 @@ from distributed.recreate_tasks import ReplayTaskScheduler
 from distributed.security import Security
 from distributed.semaphore import SemaphoreExtension
 from distributed.shuffle import ShuffleSchedulerExtension
-from distributed.spans import SpansExtension
+from distributed.spans import SpansSchedulerExtension
 from distributed.stealing import WorkStealing
 from distributed.utils import (
     All,
@@ -171,7 +171,7 @@ DEFAULT_EXTENSIONS = {
     "amm": ActiveMemoryManagerExtension,
     "memory_sampler": MemorySamplerExtension,
     "shuffle": ShuffleSchedulerExtension,
-    "spans": SpansExtension,
+    "spans": SpansSchedulerExtension,
     "stealing": WorkStealing,
 }
 
@@ -4448,7 +4448,7 @@ class Scheduler(SchedulerState, ServerNode):
                     recommendations[ts.key] = "erred"
                     break
 
-        spans_ext: SpansExtension | None = self.extensions.get("spans")
+        spans_ext: SpansSchedulerExtension | None = self.extensions.get("spans")
         if spans_ext:
             # observe_tasks does not necessarily contain all runnable tasks;
             # _generate_taskstates is not the only thing that calls new_task(). A

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -12,8 +12,8 @@ import dask.config
 from distributed.metrics import time
 
 if TYPE_CHECKING:
-    from distributed import Scheduler
-    from distributed.scheduler import TaskGroup, TaskState, TaskStateState
+    from distributed import Scheduler, Worker
+    from distributed.scheduler import TaskGroup, TaskState, TaskStateState, WorkerState
 
 
 @contextmanager
@@ -124,6 +124,8 @@ class Span:
     #: stop
     enqueued: float
 
+    _cumulative_worker_metrics: defaultdict[tuple[str, ...], float]
+
     # Support for weakrefs to a class with __slots__
     __weakref__: Any
 
@@ -136,6 +138,7 @@ class Span:
         self.enqueued = time()
         self.children = []
         self.groups = set()
+        self._cumulative_worker_metrics = defaultdict(float)
 
     def __repr__(self) -> str:
         return f"Span<name={self.name}, id={self.id}>"
@@ -262,8 +265,25 @@ class Span:
         """
         return sum(tg.nbytes_total for tg in self.traverse_groups())
 
+    @property
+    def cumulative_worker_metrics(self) -> defaultdict[tuple[str, ...], float]:
+        """Replica of Worker.digests_total and Scheduler.cumulative_worker_metrics, but
+        only for the metrics that can be attributed to the current span tree.
+        The span_id has been removed from the key.
 
-class SpansExtension:
+        At the moment of writing, all keys are
+        ``("execute", <task prefix>, <activity>, <unit>)``
+        but more may be added in the future with a different format; please test for
+        ``k[0] == "execute"``.
+        """
+        out: defaultdict[tuple[str, ...], float] = defaultdict(float)
+        for child in self.traverse_spans():
+            for k, v in child._cumulative_worker_metrics.items():
+                out[k] += v
+        return out
+
+
+class SpansSchedulerExtension:
     """Scheduler extension for spans support"""
 
     #: All Span objects by id
@@ -358,3 +378,47 @@ class SpansExtension:
             self.root_spans.append(span)
 
         return span
+
+    def heartbeat(
+        self, ws: WorkerState, data: dict[str, dict[tuple[str, ...], float]]
+    ) -> None:
+        """Triggered by SpansWorkerExtension.heartbeat().
+
+        Populate ``Span.cumulative_worker_metrics`` with data from the worker.
+
+        See also
+        --------
+        SpansWorkerExtension.heartbeat
+        """
+        for span_id, metrics in data.items():
+            span = self.spans[span_id]
+            for k, v in metrics.items():
+                span._cumulative_worker_metrics[k] += v
+
+
+class SpansWorkerExtension:
+    """Worker extension for spans support"""
+
+    worker: Worker
+
+    def __init__(self, worker: Worker):
+        self.worker = worker
+
+    def heartbeat(self) -> dict[str, dict[tuple[str, ...], float]]:
+        """Apportion the metrics that do have a span to the Spans on the scheduler
+
+        Returns
+        -------
+        ``{span_id: {("execute", prefix, activity, unit): value}}``
+
+        See also
+        --------
+        SpansSchedulerExtension.heartbeat
+        """
+        out: defaultdict[str, dict[tuple[str, ...], float]] = defaultdict(dict)
+        for k, v in self.worker.digests_total_since_heartbeat.items():
+            if isinstance(k, tuple) and k[0] == "execute":
+                _, span_id, prefix, activity, unit = k
+                assert span_id is not None
+                out[span_id]["execute", prefix, activity, unit] = v
+        return dict(out)

--- a/distributed/tests/test_reschedule.py
+++ b/distributed/tests/test_reschedule.py
@@ -52,7 +52,6 @@ async def test_raise_reschedule(c, s, a, b, state):
     await wait(futures)
     assert any(isinstance(ev, RescheduleEvent) for ev in a.state.stimulus_log)
     assert all(f.key in b.data for f in futures)
-    assert "x" not in a.state.tasks
 
 
 @pytest.mark.parametrize("state", ["executing", "long-running"])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2312,24 +2312,6 @@ async def test_idle_timeout_no_workers(c, s):
     assert s.check_idle()
 
 
-@gen_cluster(client=True)
-async def test_cumulative_worker_metrics(c, s, a, b):
-    # Race condition: metrics that are updated while idle may or may not be there already
-    assert s.cumulative_worker_metrics.keys() in (set(), {"latency"})
-    await c.submit(inc, 1, key="do_work")
-
-    await a.heartbeat()
-    await b.heartbeat()
-
-    metrics = s.cumulative_worker_metrics
-
-    # Subset of expected keys
-    assert "latency" in metrics
-    assert ("execute", "do_work", "deserialize", "seconds") in metrics
-
-    assert all(isinstance(value, float) for value in metrics.values())
-
-
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})
 async def test_bandwidth(c, s, a, b):
     start = s.bandwidth

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -4,7 +4,8 @@ import pytest
 
 from dask import delayed
 
-from distributed import Client, Event, Future
+from distributed import Client, Event, Future, wait
+from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.spans import span
 from distributed.utils_test import (
@@ -427,3 +428,105 @@ async def test_scatter_creates_tg(c, s, a, b):
     x1 = c.submit(inc, 1, key="x-1")
     assert await x1 == 2
     assert s.tasks["x-0"].group.span_id is not None
+
+
+@gen_cluster(client=True)
+async def test_worker_metrics(c, s, a, b):
+    """Test that Scheduler.cumulative_worker_metrics and Span.cumulative_worker_metrics
+    are sync'ed for all 'execute' activities
+
+    See also
+    --------
+    test_spans.py::test_send_metrics_to_scheduler
+    """
+    sid_y = []
+    with span("foo") as sid_x:
+        # Make sure that cumulative sync over multiple heartbeats works as expected
+        for _ in range(2):
+            # Span 'foo' remains the same across for iterations
+            x0 = c.submit(inc, 1, key=("x", 0), workers=[a.address])
+            x1 = c.submit(inc, 1, key=("x", 1), workers=[b.address])
+            await wait([x0, x1])
+
+            # Span 'bar' is opened and closed between for iterations
+            with span("bar") as sid_yi:
+                sid_y.append(sid_yi)
+                y0 = c.submit(inc, 1, key=("y", 0), workers=[a.address])
+                y1 = c.submit(inc, 1, key=("y", 1), workers=[b.address])
+            await wait([y0, y1])
+
+            # Populate gather_dep and get_data metrics.
+            # They will be ignored by the spans extension because they have no span_id.
+            x2 = c.submit(inc, x0, key=("x", 2), workers=[b.address])
+            x3 = c.submit(inc, x1, key=("x", 3), workers=[a.address])
+            await wait([x2, x3])
+
+            # Flush metrics from workers to scheduler
+            await a.heartbeat()
+            await b.heartbeat()
+
+            # Cleanup
+            del x0, x1, x2, x3, y0, y1
+            await async_poll_for(
+                lambda: not s.tasks and not a.state.tasks and not b.state.tasks,
+                timeout=5,
+            )
+
+    metrics = {
+        k: v
+        for k, v in s.cumulative_worker_metrics.items()
+        if isinstance(k, tuple) and k[0] == "execute"
+    }
+
+    assert list(metrics) == [
+        ("execute", sid_x, "x", "deserialize", "seconds"),
+        ("execute", sid_x, "x", "thread-cpu", "seconds"),
+        ("execute", sid_x, "x", "thread-noncpu", "seconds"),
+        ("execute", sid_x, "x", "executor", "seconds"),
+        ("execute", sid_x, "x", "other", "seconds"),
+        ("execute", sid_y[0], "y", "deserialize", "seconds"),
+        ("execute", sid_y[0], "y", "thread-cpu", "seconds"),
+        ("execute", sid_y[0], "y", "thread-noncpu", "seconds"),
+        ("execute", sid_y[0], "y", "executor", "seconds"),
+        ("execute", sid_y[0], "y", "other", "seconds"),
+        ("execute", sid_x, "x", "memory-read", "count"),
+        ("execute", sid_x, "x", "memory-read", "bytes"),
+        ("execute", sid_y[1], "y", "deserialize", "seconds"),
+        ("execute", sid_y[1], "y", "thread-cpu", "seconds"),
+        ("execute", sid_y[1], "y", "thread-noncpu", "seconds"),
+        ("execute", sid_y[1], "y", "executor", "seconds"),
+        ("execute", sid_y[1], "y", "other", "seconds"),
+    ]
+
+    if not WINDOWS:
+        assert all(v > 0 for v in metrics.values())
+
+    ext = s.extensions["spans"]
+
+    # Metrics have been synchronized from scheduler to spans
+    for (context, span_id, prefix, activity, unit), v in metrics.items():
+        assert (
+            ext.spans[span_id]._cumulative_worker_metrics[
+                context, prefix, activity, unit
+            ]
+            == v
+        )
+
+    # foo metrics include self and its child bar
+    cum_metrics = ext.spans_search_by_name["foo",][0].cumulative_worker_metrics
+    assert list(cum_metrics) == [
+        ("execute", "x", "deserialize", "seconds"),
+        ("execute", "x", "thread-cpu", "seconds"),
+        ("execute", "x", "thread-noncpu", "seconds"),
+        ("execute", "x", "executor", "seconds"),
+        ("execute", "x", "other", "seconds"),
+        ("execute", "x", "memory-read", "count"),
+        ("execute", "x", "memory-read", "bytes"),
+        ("execute", "y", "deserialize", "seconds"),
+        ("execute", "y", "thread-cpu", "seconds"),
+        ("execute", "y", "thread-noncpu", "seconds"),
+        ("execute", "y", "executor", "seconds"),
+        ("execute", "y", "other", "seconds"),
+    ]
+    for k, v in cum_metrics.items():
+        assert v == sum(sp._cumulative_worker_metrics[k] for sp in ext.spans.values())

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -11,7 +11,7 @@ import pytest
 import dask
 
 import distributed
-from distributed import Event, Worker, wait
+from distributed import Event, Reschedule, Scheduler, Worker, get_worker, wait
 from distributed.compatibility import WINDOWS
 from distributed.metrics import context_meter, meter
 from distributed.utils_test import (
@@ -20,23 +20,35 @@ from distributed.utils_test import (
     async_poll_for,
     gen_cluster,
     inc,
+    slowinc,
     wait_for_state,
 )
 
 
-def get_digests(w: Worker, allow: str | Collection[str] = ()) -> dict[Hashable, float]:
-    # import pprint; pprint.pprint(dict(w.digests_total))
+def get_digests(
+    w: Worker | Scheduler, allow: str | Collection[str] = ()
+) -> dict[Hashable, float]:
     if isinstance(allow, str):
         allow = (allow,)
+    d = w.digests_total if isinstance(w, Worker) else w.cumulative_worker_metrics
+    # import pprint; pprint.pprint(dict(d))
     digests = {
         k: v
-        for k, v in w.digests_total.items()
+        for k, v in d.items()
         if k
         not in {"latency", "tick-duration", "transfer-bandwidth", "transfer-duration"}
         and (any(a in k for a in allow) or not allow)
     }
     assert all(v >= 0 for v in digests.values()), digests
     return digests
+
+
+def span_id(s: Scheduler) -> str | None:
+    ext = s.extensions["spans"]
+    defaults = ext.spans_search_by_name["default",]
+    # This is an arbitrary constraint enforced by the tests below
+    assert len(defaults) == 1
+    return defaults[0].id
 
 
 @gen_cluster(client=True, config={"distributed.worker.memory.target": 1e-9})
@@ -71,25 +83,25 @@ async def test_task_lifecycle(c, s, a, b):
         ("gather-dep", "other", "seconds"),
         # a.execute()
         # -> Deserialize run_spec
-        ("execute", "z", "deserialize", "seconds"),
+        ("execute", span_id(s), "z", "deserialize", "seconds"),
         # -> Unspill inputs
         # (There's also another execute-deserialize-seconds entry)
-        ("execute", "z", "disk-read", "seconds"),
-        ("execute", "z", "disk-read", "count"),
-        ("execute", "z", "disk-read", "bytes"),
-        ("execute", "z", "decompress", "seconds"),
+        ("execute", span_id(s), "z", "disk-read", "seconds"),
+        ("execute", span_id(s), "z", "disk-read", "count"),
+        ("execute", span_id(s), "z", "disk-read", "bytes"),
+        ("execute", span_id(s), "z", "decompress", "seconds"),
         # -> Run in thread
-        ("execute", "z", "thread-cpu", "seconds"),
-        ("execute", "z", "thread-noncpu", "seconds"),
-        ("execute", "z", "executor", "seconds"),
+        ("execute", span_id(s), "z", "thread-cpu", "seconds"),
+        ("execute", span_id(s), "z", "thread-noncpu", "seconds"),
+        ("execute", span_id(s), "z", "executor", "seconds"),
         # Spill output; added by _transition_to_memory
-        ("execute", "z", "serialize", "seconds"),
-        ("execute", "z", "compress", "seconds"),
-        ("execute", "z", "disk-write", "seconds"),
-        ("execute", "z", "disk-write", "count"),
-        ("execute", "z", "disk-write", "bytes"),
+        ("execute", span_id(s), "z", "serialize", "seconds"),
+        ("execute", span_id(s), "z", "compress", "seconds"),
+        ("execute", span_id(s), "z", "disk-write", "seconds"),
+        ("execute", span_id(s), "z", "disk-write", "count"),
+        ("execute", span_id(s), "z", "disk-write", "bytes"),
         # Delta to end-to-end runtime as seen from the worker state machine
-        ("execute", "z", "other", "seconds"),
+        ("execute", span_id(s), "z", "other", "seconds"),
         # a.get_data() (triggered by the client retrieving the Future for z)
         # Unspill
         ("get-data", "disk-read", "seconds"),
@@ -105,8 +117,8 @@ async def test_task_lifecycle(c, s, a, b):
     assert list(get_digests(a)) == expect
 
     assert get_digests(a, allow="count") == {
-        ("execute", "z", "disk-read", "count"): 2,
-        ("execute", "z", "disk-write", "count"): 1,
+        ("execute", span_id(s), "z", "disk-read", "count"): 2,
+        ("execute", span_id(s), "z", "disk-write", "count"): 1,
         ("gather-dep", "disk-write", "count"): 1,
         ("get-data", "disk-read", "count"): 1,
     }
@@ -118,8 +130,10 @@ async def test_task_lifecycle(c, s, a, b):
 async def test_async_task(c, s, a):
     """Test that async tasks are metered"""
     await c.submit(asyncio.sleep, 0.1, key=("x-123", 0))
-    assert a.digests_total["execute", "x" "thread-cpu", "seconds"] == 0
-    assert 0 < a.digests_total["execute", "x", "thread-noncpu", "seconds"] < 1
+    assert a.digests_total["execute", span_id(s), "x" "thread-cpu", "seconds"] == 0
+    assert (
+        0 < a.digests_total["execute", span_id(s), "x", "thread-noncpu", "seconds"] < 1
+    )
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -136,19 +150,21 @@ async def test_custom_executor(c, s, a):
             await c.submit(sleep, 0.1)
 
     assert list(get_digests(a, "execute")) == [
-        ("execute", "sleep", "deserialize", "seconds"),
-        ("execute", "sleep", "executor", "seconds"),
-        ("execute", "sleep", "other", "seconds"),
+        ("execute", span_id(s), "sleep", "deserialize", "seconds"),
+        ("execute", span_id(s), "sleep", "executor", "seconds"),
+        ("execute", span_id(s), "sleep", "other", "seconds"),
     ]
 
-    assert 0 < a.digests_total["execute", "sleep", "executor", "seconds"] < 1
+    assert (
+        0 < a.digests_total["execute", span_id(s), "sleep", "executor", "seconds"] < 1
+    )
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_run_spec_deserialization(c, s, a):
     """Test that deserialization of run_spec is metered"""
     await c.submit(inc, 1, key="x")
-    assert 0 < a.digests_total["execute", "x", "deserialize", "seconds"] < 1
+    assert 0 < a.digests_total["execute", span_id(s), "x", "deserialize", "seconds"] < 1
 
 
 @gen_cluster(client=True)
@@ -164,8 +180,8 @@ async def test_offload(c, s, a, b, monkeypatch):
     assert list(get_digests(b, {"offload", "serialize", "deserialize"})) == [
         ("gather-dep", "offload", "seconds"),
         ("gather-dep", "deserialize", "seconds"),
-        ("execute", "y", "offload", "seconds"),
-        ("execute", "y", "deserialize", "seconds"),
+        ("execute", span_id(s), "y", "offload", "seconds"),
+        ("execute", span_id(s), "y", "deserialize", "seconds"),
         ("get-data", "offload", "seconds"),
         ("get-data", "serialize", "seconds"),
     ]
@@ -177,7 +193,7 @@ async def test_execute_failed(c, s, a):
     x = c.submit(lambda: 1 / 0, key="x")
     await wait(x)
 
-    assert list(get_digests(a)) == [("execute", "x", "failed", "seconds")]
+    assert list(get_digests(a)) == [("execute", span_id(s), "x", "failed", "seconds")]
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -191,7 +207,9 @@ async def test_cancelled_execute(c, s, a):
     await ev.set()
     await async_poll_for(lambda: not a.state.tasks, timeout=5)
 
-    assert list(get_digests(a)) == [("execute", "x", "cancelled", "seconds")]
+    assert list(get_digests(a)) == [
+        ("execute", span_id(s), "x", "cancelled", "seconds")
+    ]
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -346,18 +364,18 @@ async def test_user_metrics_sync(c, s, a):
     await wait(c.submit(f, key="x"))
 
     assert list(get_digests(a)) == [
-        ("execute", "x", "deserialize", "seconds"),
-        ("execute", "x", "I/O", "seconds"),
-        ("execute", "x", "thread-cpu", "seconds"),
-        ("execute", "x", "thread-noncpu", "seconds"),
-        ("execute", "x", "executor", "seconds"),
-        ("execute", "x", "other", "seconds"),
+        ("execute", span_id(s), "x", "deserialize", "seconds"),
+        ("execute", span_id(s), "x", "I/O", "seconds"),
+        ("execute", span_id(s), "x", "thread-cpu", "seconds"),
+        ("execute", span_id(s), "x", "thread-noncpu", "seconds"),
+        ("execute", span_id(s), "x", "executor", "seconds"),
+        ("execute", span_id(s), "x", "other", "seconds"),
     ]
-    assert get_digests(a)["execute", "x", "I/O", "seconds"] == 5
-    assert get_digests(a)["execute", "x", "thread-cpu", "seconds"] == 0
-    assert get_digests(a)["execute", "x", "thread-noncpu", "seconds"] == 0
-    assert get_digests(a)["execute", "x", "executor", "seconds"] == 0
-    assert get_digests(a)["execute", "x", "other", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "I/O", "seconds"] == 5
+    assert get_digests(a)["execute", span_id(s), "x", "thread-cpu", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "thread-noncpu", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "executor", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "other", "seconds"] == 0
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -369,14 +387,14 @@ async def test_user_metrics_async(c, s, a):
     await wait(c.submit(f, key="x"))
 
     assert list(get_digests(a)) == [
-        ("execute", "x", "deserialize", "seconds"),
-        ("execute", "x", "I/O", "seconds"),
-        ("execute", "x", "thread-noncpu", "seconds"),
-        ("execute", "x", "other", "seconds"),
+        ("execute", span_id(s), "x", "deserialize", "seconds"),
+        ("execute", span_id(s), "x", "I/O", "seconds"),
+        ("execute", span_id(s), "x", "thread-noncpu", "seconds"),
+        ("execute", span_id(s), "x", "other", "seconds"),
     ]
-    assert get_digests(a)["execute", "x", "I/O", "seconds"] == 5
-    assert get_digests(a)["execute", "x", "thread-noncpu", "seconds"] == 0
-    assert get_digests(a)["execute", "x", "other", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "I/O", "seconds"] == 5
+    assert get_digests(a)["execute", span_id(s), "x", "thread-noncpu", "seconds"] == 0
+    assert get_digests(a)["execute", span_id(s), "x", "other", "seconds"] == 0
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -389,11 +407,11 @@ async def test_user_metrics_fail(c, s, a):
     await wait(c.submit(f, key="x"))
 
     assert list(get_digests(a)) == [
-        ("execute", "x", "I/O", "bytes"),
-        ("execute", "x", "failed", "seconds"),
+        ("execute", span_id(s), "x", "I/O", "bytes"),
+        ("execute", span_id(s), "x", "failed", "seconds"),
     ]
-    assert get_digests(a)["execute", "x", "I/O", "bytes"] == 100
-    assert get_digests(a)["execute", "x", "failed", "seconds"] < 1
+    assert get_digests(a)["execute", span_id(s), "x", "I/O", "bytes"] == 100
+    assert get_digests(a)["execute", span_id(s), "x", "failed", "seconds"] < 1
 
 
 @gen_cluster(client=True, nthreads=[("", 3)])
@@ -415,7 +433,125 @@ async def test_do_not_leak_metrics(c, s, a, b):
     await wait([x, y, z])
 
     assert get_digests(a, "ping") == {
-        ("execute", "x", "ping", "x", "count"): 10,
-        ("execute", "y", "ping", "y", "count"): 10,
-        ("execute", "z", "ping", "z", "count"): 10,
+        ("execute", span_id(s), "x", "ping", "x", "count"): 10,
+        ("execute", span_id(s), "y", "ping", "y", "count"): 10,
+        ("execute", span_id(s), "z", "ping", "z", "count"): 10,
     }
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 2,
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_reschedule(c, s, a, b):
+    """A task raises Reschedule()
+
+    See also
+    --------
+    test_reschedule.py
+    """
+    a_address = a.address
+
+    def f(x):
+        sleep(0.1)
+        if get_worker().address == a_address:
+            raise Reschedule()
+
+    futures = c.map(f, range(4), key=["x-1", "x-2", "x-3", "x-4"])
+    futures2 = c.map(slowinc, range(10), delay=0.1, key="clog", workers=[a.address])
+    await wait(futures)
+    assert all(f.key in b.data for f in futures)
+
+    evs = get_digests(a, "x")
+    k = ("execute", span_id(s), "x", "cancelled", "seconds")
+    assert list(evs) == [k]
+    assert evs[k] > 0
+
+
+@gen_cluster(
+    client=True, scheduler_kwargs={"extensions": {}}, worker_kwargs={"extensions": {}}
+)
+async def test_send_metrics_to_scheduler(c, s, a, b):
+    """Test that Worker.digests_total are sync'ed by the heartbeat to
+    Scheduler.cumulative_worker_metrics
+
+    See also
+    --------
+    test_spans.py::test_worker_metrics
+    """
+    # Race condition: metrics that are updated while idle may or may not be there already
+    assert s.cumulative_worker_metrics.keys() in (set(), {"latency"})
+
+    x0 = c.submit(inc, 1, key=("x", 0), workers=[a.address])
+    x1 = c.submit(inc, 1, key=("x", 1), workers=[b.address])
+    # Trigger gather_dep and get_data
+    x2 = c.submit(inc, x0, key=("x", 2), workers=[b.address])
+    x3 = c.submit(inc, x1, key=("x", 3), workers=[a.address])
+    await wait([x2, x3])
+    # Flush metrics from workers to scheduler
+    await a.heartbeat()
+    await b.heartbeat()
+
+    # Make sure that cumulative sync over multiple heartbeats works as expected
+    x4 = c.submit(inc, 1, key=("x", 4))
+    await wait(x4)
+    await a.heartbeat()
+    await b.heartbeat()
+
+    # Metrics from workers have been summed up on scheduler
+    a_metrics = get_digests(a)
+    b_metrics = get_digests(b)
+    s_metrics = get_digests(s)
+    assert (
+        list(a_metrics)
+        == list(b_metrics)
+        == list(s_metrics)
+        == [
+            ("execute", None, "x", "deserialize", "seconds"),
+            ("execute", None, "x", "thread-cpu", "seconds"),
+            ("execute", None, "x", "thread-noncpu", "seconds"),
+            ("execute", None, "x", "executor", "seconds"),
+            ("execute", None, "x", "other", "seconds"),
+            ("get-data", "memory-read", "count"),
+            ("get-data", "memory-read", "bytes"),
+            ("get-data", "serialize", "seconds"),
+            ("get-data", "compress", "seconds"),
+            ("gather-dep", "decompress", "seconds"),
+            ("gather-dep", "deserialize", "seconds"),
+            ("gather-dep", "network", "seconds"),
+            ("gather-dep", "other", "seconds"),
+            ("get-data", "network", "seconds"),
+            ("execute", None, "x", "memory-read", "count"),
+            ("execute", None, "x", "memory-read", "bytes"),
+        ]
+    )
+    for k in s_metrics:
+        if not WINDOWS:
+            assert a_metrics[k] > 0
+            assert b_metrics[k] > 0
+        assert s_metrics[k] == a_metrics[k] + b_metrics[k]
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    scheduler_kwargs={"extensions": {}},
+    worker_kwargs={"extensions": {}},
+)
+async def test_no_spans_extension(c, s, a):
+    await wait(c.submit(lambda: 1 / 0, key="x"))
+    await wait(c.submit(inc, 1, key="y"))
+    await a.heartbeat()
+
+    digests = get_digests(a)
+    assert list(digests) == [
+        ("execute", None, "x", "failed", "seconds"),
+        ("execute", None, "y", "deserialize", "seconds"),
+        ("execute", None, "y", "thread-cpu", "seconds"),
+        ("execute", None, "y", "thread-noncpu", "seconds"),
+        ("execute", None, "y", "executor", "seconds"),
+        ("execute", None, "y", "other", "seconds"),
+    ]
+    for k, v in digests.items():
+        assert s.cumulative_worker_metrics[k] == v

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -93,6 +93,7 @@ from distributed.pubsub import PubSubWorkerExtension
 from distributed.security import Security
 from distributed.shuffle import ShuffleWorkerExtension
 from distributed.sizeof import safe_sizeof as sizeof
+from distributed.spans import SpansWorkerExtension
 from distributed.threadpoolexecutor import ThreadPoolExecutor
 from distributed.threadpoolexecutor import secede as tpe_secede
 from distributed.utils import (
@@ -172,6 +173,7 @@ LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 DEFAULT_EXTENSIONS: dict[str, type] = {
     "pubsub": PubSubWorkerExtension,
     "shuffle": ShuffleWorkerExtension,
+    "spans": SpansWorkerExtension,
 }
 
 DEFAULT_METRICS: dict[str, Callable[[Worker], Any]] = {}
@@ -1056,8 +1058,6 @@ class Worker(BaseWorker, ServerNode):
             event_loop_interval=self._tick_interval_observed,
         )
 
-        self.digests_total_since_heartbeat.clear()
-
         monitor_recent = self.monitor.recent()
         # Convert {foo.bar: 123} to {foo: {bar: 123}}
         for k, v in monitor_recent.items():
@@ -1251,6 +1251,8 @@ class Worker(BaseWorker, ServerNode):
                     if hasattr(extension, "heartbeat")
                 },
             )
+            self.digests_total_since_heartbeat.clear()
+
             end = time()
             middle = (start + end) / 2
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3604,12 +3604,13 @@ class BaseWorker(abc.ABC):
         self.state = state
         self._async_instructions = set()
 
-    def _start_async_instruction(
+    def _start_async_instruction(  # type: ignore[valid-type]
         self,
         task_name: str,
         func: Callable[P, Awaitable[StateMachineEvent]],
         /,
         *args: P.args,
+        span_id: str | None = None,
         **kwargs: P.kwargs,
     ) -> None:
         """Execute an asynchronous instruction inside an asyncio task"""
@@ -3622,12 +3623,15 @@ class BaseWorker(abc.ABC):
 
         task = asyncio.create_task(wrapper(), name=task_name)
         self._async_instructions.add(task)
-        task.add_done_callback(partial(self._finish_async_instruction, ledger=ledger))
+        task.add_done_callback(
+            partial(self._finish_async_instruction, ledger=ledger, span_id=span_id)
+        )
 
     def _finish_async_instruction(
         self,
         task: asyncio.Task[StateMachineEvent],
         ledger: DelayedMetricsLedger,
+        span_id: str | None,
     ) -> None:
         """The asynchronous instruction just completed; process the returned
         stimulus.
@@ -3647,15 +3651,19 @@ class BaseWorker(abc.ABC):
             # Capture metric events in _transition_to_memory()
             self.handle_stimulus(stim)
 
-        self._finalize_metrics(stim, ledger)
+        self._finalize_metrics(stim, ledger, span_id)
 
     def _finalize_metrics(
         self,
         stim: StateMachineEvent,
         ledger: DelayedMetricsLedger,
+        span_id: str | None = None,
     ) -> None:
-        activity: tuple[str, ...]
+        activity: tuple[str | None, ...]
         coarse_time: str | Literal[False]
+
+        if not isinstance(stim, ExecuteDoneEvent):
+            assert span_id is None
 
         if isinstance(stim, GatherDepSuccessEvent):
             activity = ("gather-dep",)
@@ -3677,16 +3685,16 @@ class BaseWorker(abc.ABC):
             coarse_time = "busy"
 
         elif isinstance(stim, ExecuteSuccessEvent):
-            activity = ("execute", key_split(stim.key))
+            activity = ("execute", span_id, key_split(stim.key))
             ts = self.state.tasks.get(stim.key)
             coarse_time = False if ts and ts.state == "memory" else "cancelled"
 
         elif isinstance(stim, ExecuteFailureEvent):
-            activity = ("execute", key_split(stim.key))
+            activity = ("execute", span_id, key_split(stim.key))
             coarse_time = "failed"
 
         elif isinstance(stim, RescheduleEvent):
-            activity = ("execute", key_split(stim.key))
+            activity = ("execute", span_id, key_split(stim.key))
             coarse_time = "cancelled"
 
         else:
@@ -3731,10 +3739,12 @@ class BaseWorker(abc.ABC):
                 )
 
             elif isinstance(inst, Execute):
+                ts = self.state.tasks[inst.key]
                 self._start_async_instruction(
                     f"execute({inst.key})",
                     self.execute,
                     inst.key,
+                    span_id=ts.span_id,
                     stimulus_id=inst.stimulus_id,
                 )
 


### PR DESCRIPTION
Of the whole test suite, this use case was triggered (not always) exclusively by test_queue.py::test_race.